### PR TITLE
Add capability to swarm bot to ensure message propagation

### DIFF
--- a/swarm_bot/src/message_types.py
+++ b/swarm_bot/src/message_types.py
@@ -9,3 +9,4 @@ class MessageTypes(Enum):
     NEW_TASK = 5
     REQUEST_TASK_TRANSFER = 6
     BASIC_PROPAGATION_MESSAGE = 7
+    SYNC_MESSAGES = 8

--- a/swarm_bot/src/swarm_bot.py
+++ b/swarm_bot/src/swarm_bot.py
@@ -128,13 +128,8 @@ class SwarmBot(MessageChannelUser):
                 id_list = message_payload["MSG_LIST"]
                 missing_msgs = []
 
-
                 rcvd_msg_ids = list(self.msg_inbox.keys())
                 sent_msg_ids = list(self.sent_messages.keys())
-
-                print(id_list)
-                print(rcvd_msg_ids)
-                print(sent_msg_ids)
 
                 for msg_id in id_list:
                     if (msg_id not in rcvd_msg_ids) and (msg_id not in sent_msg_ids):
@@ -333,8 +328,7 @@ class SwarmBot(MessageChannelUser):
 
         response = self.create_message(bot_id, MessageTypes.SYNC_MESSAGES, {"MSG_LIST": msg_list}, True)
         missing_msg_list = response[0].get_message_payload()["MSG_LIST"]
-        print("HERE")
-        print(missing_msg_list)
+
         for msg_id in missing_msg_list:
             curr_msg = None
             if msg_id in self.sent_messages:

--- a/swarm_bot/test/test_swarm_bot_syncing.py
+++ b/swarm_bot/test/test_swarm_bot_syncing.py
@@ -1,0 +1,68 @@
+import logging
+import unittest
+import time
+from unittest.mock import MagicMock
+
+from swarm_bot.test.swarm_bot_test_class import SwarmBotTestClass
+from swarm_bot.src.swarm_bot_sensor import SwarmBotSensor
+
+
+class SimpleSensor(SwarmBotSensor):
+    def __init__(self):
+        super().__init__()
+
+    def read_from_sensor(self, additional_params):
+        return True
+
+
+class TestSwarmInformationPropagation(SwarmBotTestClass):
+    def test_swarm_bot_will_send_previously_propagated_messages_to_a_newly_connected_bot(self):
+        test_swarm_bot_1 = self.create_swarm_bot()
+        test_swarm_bot_2 = self.create_swarm_bot()
+        test_swarm_bot_3 = self.create_swarm_bot()
+
+        test_swarm_bot_1.connect_to_swarm_bot(test_swarm_bot_2)
+
+        msg_id = test_swarm_bot_1.send_basic_propagation_message()
+
+        start_time = time.time()
+        while ((time.time() < start_time + 10) and (not test_swarm_bot_2.received_msg_with_id(msg_id))):
+            pass
+
+        self.assertTrue(test_swarm_bot_2.received_msg_with_id(msg_id))
+        self.assertFalse(test_swarm_bot_3.received_msg_with_id(msg_id))
+
+        test_swarm_bot_1.connect_to_swarm_bot(test_swarm_bot_3)
+
+        start_time = time.time()
+        while ((time.time() < start_time + 10) and (not test_swarm_bot_3.received_msg_with_id(msg_id))):
+            pass
+
+        self.assertTrue(test_swarm_bot_2.received_msg_with_id(msg_id))
+        self.assertTrue(test_swarm_bot_3.received_msg_with_id(msg_id))
+
+    def test_swarm_bot_will_resync_every_tenth_message_received(self):
+        test_swarm_bot_1 = self.create_swarm_bot()
+        test_swarm_bot_2 = self.create_swarm_bot()
+        test_swarm_bot_3 = self.create_swarm_bot()
+
+        test_swarm_bot_1.connect_to_swarm_bot(test_swarm_bot_2)
+        test_swarm_bot_1.connect_to_swarm_bot(test_swarm_bot_3)
+
+        test_swarm_bot_2.sync_with_bot = MagicMock()
+        test_swarm_bot_3.sync_with_bot = MagicMock()
+
+        for _ in range(10):
+            msg_id = test_swarm_bot_1.send_basic_propagation_message()
+
+            start_time = time.time()
+            while ((time.time() < start_time + 10) and (not test_swarm_bot_2.received_msg_with_id(msg_id) or not test_swarm_bot_3.received_msg_with_id(msg_id))):
+                pass
+
+        test_swarm_bot_2.sync_with_bot.assert_called_with(test_swarm_bot_1.get_id())
+        test_swarm_bot_3.sync_with_bot.assert_called_with(test_swarm_bot_1.get_id())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/swarm_bot/test/test_swarm_information_propagation.py
+++ b/swarm_bot/test/test_swarm_information_propagation.py
@@ -25,8 +25,6 @@ class TestSwarmInformationPropagation(SwarmBotTestClass):
 
         msg_id = test_swarm_bot_1.send_basic_propagation_message()
 
-        print(msg_id)
-
         start_time = time.time()
         while ((time.time() < start_time + 10) and not (test_swarm_bot_2.received_msg_with_id(msg_id) and test_swarm_bot_3.received_msg_with_id(msg_id))):
             pass
@@ -55,8 +53,6 @@ class TestSwarmInformationPropagation(SwarmBotTestClass):
         test_swarm_bot_3.connect_to_swarm_bot(test_swarm_bot_7)
 
         msg_id = test_swarm_bot_1.send_basic_propagation_message()
-
-        print(msg_id)
 
         start_time = time.time()
         while ((time.time() < start_time + 10) and not (test_swarm_bot_4.received_msg_with_id(msg_id) and test_swarm_bot_5.received_msg_with_id(msg_id) and test_swarm_bot_6.received_msg_with_id(msg_id) and test_swarm_bot_7.received_msg_with_id(msg_id))):
@@ -87,8 +83,6 @@ class TestSwarmInformationPropagation(SwarmBotTestClass):
         test_swarm_bot_5.connect_to_swarm_bot(test_swarm_bot_1)
 
         msg_id = test_swarm_bot_1.send_basic_propagation_message()
-
-        print(msg_id)
 
         start_time = time.time()
         while ((time.time() < start_time + 10) and not (test_swarm_bot_2.received_msg_with_id(msg_id) and test_swarm_bot_3.received_msg_with_id(msg_id) and test_swarm_bot_4.received_msg_with_id(msg_id) and test_swarm_bot_5.received_msg_with_id(msg_id))):


### PR DESCRIPTION
Adds a sync method to the swarm bot to sync previously propagated messages to conencted bots. Upon initial connection or a threshold of number of messages received, a bot will sync up with its adjacent bots to ensure that they have received the same propagated messages. This helps to ensure all bots receive propagated messages.

The downside to this implementation is that it can still lead to bubbles in the network where it takes a while for missing propagated messages to get propagated.

https://github.com/BramSrna/SwarmManager/projects/8#card-84121717